### PR TITLE
fix: release camera on stream cancel to prevent conflicts with other camera packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,34 @@
 # Changelog
+## [0.1.5] - 2026-03-17
+
+### Fixed
+- Camera is no longer initialized eagerly on activity attach. It now starts
+  only when a Dart listener subscribes to `poseLandmarkStream` (`onListen`)
+  and is fully released when the subscription is cancelled (`onCancel`).
+  This fixes a conflict where the plugin held the camera hardware even when
+  no pose detection was active, preventing the `camera` package and other
+  consumers from opening the camera on other screens.
+
+### Changed
+- `CameraManager.startCamera()` is no longer called inside `onAttachedToActivity`.
+  The plugin now only constructs the manager at attach time and defers all
+  hardware access to stream subscription time.
+- `onCancel` now calls `releaseCamera()` (unbinds `ProcessCameraProvider`)
+  in addition to `disableAnalysis()`, ensuring the hardware is fully freed.
+- Stream listener guards added (`!mounted` check) to prevent `setState`
+  calls after widget disposal.
+- `IPoseManager` extended with `releaseCamera()` to formalize the release
+  contract across both `CameraManager` and `MockPoseManager`.
+- `MockPoseManager.releaseCamera()` implemented as a no-op.
+
+### Example app
+- `_poseSubscription` changed from `late` to nullable (`?`) so `dispose()`
+  is safe even if the stream was never started.
+- Replaced deprecated `withOpacity()` calls with `withAlpha()`.
+- Replaced `print()` calls with `debugPrint()`.
+- Repeated stat label containers extracted into a `_StatChip` widget.
+
+
 
 ## [0.1.4] - 2026-03-13
 

--- a/android/src/main/kotlin/com/carecode/flutter_mp_pose_lm/CameraManager.kt
+++ b/android/src/main/kotlin/com/carecode/flutter_mp_pose_lm/CameraManager.kt
@@ -270,4 +270,12 @@ class CameraManager(private val activity: Activity) : PoseLandmarkerHelper.Landm
             eventSink.get()?.error("POSE_ERROR", error, mapOf("code" to errorCode))
         }
     }
+    override  fun releaseCamera(){
+        disableAnalysis();
+        try{
+            ProcessCameraProvider.getInstance(activity).get().unbindAll()
+        }catch (e:Exception){
+            if(isLoggingEnabled) Log.e("CameraManager", "Failed to release camera provider", e)
+        }
+    }
 }

--- a/android/src/main/kotlin/com/carecode/flutter_mp_pose_lm/FlutterMpPoseLandmarkerPlugin.kt
+++ b/android/src/main/kotlin/com/carecode/flutter_mp_pose_lm/FlutterMpPoseLandmarkerPlugin.kt
@@ -68,6 +68,14 @@ class FlutterMpPoseLandmarkerPlugin : FlutterPlugin, EventChannel.StreamHandler,
                     (poseManager as? CameraManager)?.switchCamera()
                     result.success(null)
                 }
+                "releaseCamera" -> {
+                    poseManager?.releaseCamera()
+                    result.success(null)
+                }
+
+                "restoreCamera" -> {
+                    startCameraIfAvailable()
+                }
 
                 "checkCameraPermission" -> {
                     val hasPermission = androidx.core.content.ContextCompat.checkSelfPermission(
@@ -115,7 +123,7 @@ class FlutterMpPoseLandmarkerPlugin : FlutterPlugin, EventChannel.StreamHandler,
             Log.d("PoseLandmarkerPlugin", "Emulator detected — using MockPoseManager")
             MockPoseManager()
         } else {
-            CameraManager(activity!!).apply { startCamera() }
+            CameraManager(activity!!)
         }
 
         platformViewRegistry?.registerViewFactory("camera_preview_view",
@@ -140,13 +148,19 @@ class FlutterMpPoseLandmarkerPlugin : FlutterPlugin, EventChannel.StreamHandler,
 
     override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
         poseManager?.apply {
+            val cameraManager = poseManager as? CameraManager
             setEventSink(events)
+            startCameraIfAvailable() // only now does it touch the hardware
             enableAnalysis()
         }
     }
 
+    private fun startCameraIfAvailable() {
+        (poseManager as? CameraManager)?.startCamera()
+    }
     override fun onCancel(arguments: Any?) {
         poseManager?.disableAnalysis()
+        (poseManager as? CameraManager)?.releaseCamera()
     }
 
     override fun onDetachedFromActivity() {

--- a/android/src/main/kotlin/com/carecode/flutter_mp_pose_lm/IPoseManager.kt
+++ b/android/src/main/kotlin/com/carecode/flutter_mp_pose_lm/IPoseManager.kt
@@ -10,4 +10,5 @@ interface IPoseManager {
     fun pauseAnalysis()
     fun resumeAnalysis()
     fun dispose()
+    fun releaseCamera()
 }

--- a/android/src/main/kotlin/com/carecode/flutter_mp_pose_lm/MockPoseManager.kt
+++ b/android/src/main/kotlin/com/carecode/flutter_mp_pose_lm/MockPoseManager.kt
@@ -88,6 +88,9 @@ class MockPoseManager : IPoseManager {
         }
     }
 
+    override fun releaseCamera() { /* nothing to release */ }
+
+
     private fun buildMockLandmarks(armSwing: Float): List<FloatArray> {
         return listOf(
             floatArrayOf(0.50f, 0.10f, 0f),  // 0  nose

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,19 +35,21 @@ class PoseLandmarkerView extends StatefulWidget {
 }
 
 class _PoseLandmarkerViewState extends State<PoseLandmarkerView> {
-  int delegate = 0; // 0=CPU, 1=GPU
-  int model = 1; // 0=Full, 1=Lite, 2=Heavy
-  // Confidence parameters
+  int delegate = 0;
+  int model = 1;
+
   double _minPoseDetectionConfidence = 0.5;
   double _minPoseTrackingConfidence = 0.5;
   double _minPosePresenceConfidence = 0.5;
 
   List<PoseLandmarkPoint> _landmarks = [];
-  late StreamSubscription<PoseLandMarker> _poseSubscription;
+
+  // Nullable so dispose() is safe even if stream never started
+  StreamSubscription<PoseLandMarker>? _poseSubscription;
 
   bool _detectionPaused = false;
   bool _loggingEnabled = true;
-  String _cameraLens = "Back";
+  String _cameraLens = 'Back';
 
   int _fps = 0;
   int _frameCount = 0;
@@ -73,45 +75,43 @@ class _PoseLandmarkerViewState extends State<PoseLandmarkerView> {
       minPosePresenceConfidence: _minPosePresenceConfidence,
     );
 
+    // Subscribing here triggers onListen in the plugin → startCamera() runs.
+    // Cancelling in dispose() triggers onCancel → releaseCamera() runs,
+    // freeing the hardware so other packages like camera can use it freely.
     _poseSubscription = PoseLandmarker.poseLandmarkStream.listen((pose) {
-      if (!_detectionPaused) {
-        setState(() {
-          _landmarks = pose.landmarks;
-
-          // FPS calculation
-          _frameCount++;
-          int now = DateTime.now().millisecondsSinceEpoch;
-          if (now - _lastTimestamp >= 1000) {
-            _fps = _frameCount;
-            _frameCount = 0;
-            _lastTimestamp = now;
-            if (_loggingEnabled) print("FPS: $_fps");
-          }
-        });
-      }
+      if (_detectionPaused || !mounted) return;
+      setState(() {
+        _landmarks = pose.landmarks;
+        _frameCount++;
+        final now = DateTime.now().millisecondsSinceEpoch;
+        if (now - _lastTimestamp >= 1000) {
+          _fps = _frameCount;
+          _frameCount = 0;
+          _lastTimestamp = now;
+          if (_loggingEnabled) debugPrint('FPS: $_fps');
+        }
+      });
     });
   }
 
   void _switchCamera() {
     PoseLandmarker.switchCamera();
     setState(() {
-      _cameraLens = _cameraLens == "Back" ? "Front" : "Back";
+      _cameraLens = _cameraLens == 'Back' ? 'Front' : 'Back';
     });
-    if (_loggingEnabled) print("Switched camera to $_cameraLens");
+    if (_loggingEnabled) debugPrint('Switched camera to $_cameraLens');
   }
 
   void _toggleLogging() {
-    setState(() {
-      _loggingEnabled = !_loggingEnabled;
-    });
-    print("Logging: $_loggingEnabled");
+    setState(() => _loggingEnabled = !_loggingEnabled);
+    debugPrint('Logging: $_loggingEnabled');
   }
 
   void _pauseResumeDetection() {
-    setState(() {
-      _detectionPaused = !_detectionPaused;
-    });
-    print(_detectionPaused ? "Detection Paused" : "Detection Resumed");
+    setState(() => _detectionPaused = !_detectionPaused);
+    if (_loggingEnabled) {
+      debugPrint(_detectionPaused ? 'Detection paused' : 'Detection resumed');
+    }
   }
 
   void _applyConfidenceSettings() {
@@ -132,15 +132,20 @@ class _PoseLandmarkerViewState extends State<PoseLandmarkerView> {
       );
 
       if (_loggingEnabled) {
-        print(
-            "Updated confidence: detection=$_minPoseDetectionConfidence, tracking=$_minPoseTrackingConfidence, presence=$_minPosePresenceConfidence");
+        debugPrint('Confidence updated — '
+            'detection: $_minPoseDetectionConfidence, '
+            'tracking: $_minPoseTrackingConfidence, '
+            'presence: $_minPosePresenceConfidence');
       }
     });
   }
 
   @override
   void dispose() {
-    _poseSubscription.cancel();
+    // Cancelling the subscription triggers onCancel in the plugin,
+    // which calls releaseCamera() → ProcessCameraProvider.unbindAll()
+    // → hardware is free for the camera package or any other consumer.
+    _poseSubscription?.cancel();
     _detectionController.dispose();
     _trackingController.dispose();
     _presenceController.dispose();
@@ -156,19 +161,19 @@ class _PoseLandmarkerViewState extends State<PoseLandmarkerView> {
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
             FloatingActionButton(
-              heroTag: "switchCamera",
-              child: const Icon(Icons.cameraswitch),
+              heroTag: 'switchCamera',
               onPressed: _switchCamera,
+              child: const Icon(Icons.cameraswitch),
             ),
             FloatingActionButton(
-              heroTag: "pauseResume",
-              child: Icon(_detectionPaused ? Icons.play_arrow : Icons.pause),
+              heroTag: 'pauseResume',
               onPressed: _pauseResumeDetection,
+              child: Icon(_detectionPaused ? Icons.play_arrow : Icons.pause),
             ),
             FloatingActionButton(
-              heroTag: "loggingToggle",
-              child: const Icon(Icons.bug_report),
+              heroTag: 'loggingToggle',
               onPressed: _toggleLogging,
+              child: const Icon(Icons.bug_report),
             ),
           ],
         ),
@@ -185,7 +190,7 @@ class _PoseLandmarkerViewState extends State<PoseLandmarkerView> {
             child: Container(
               decoration: BoxDecoration(
                 border: Border.all(color: Colors.white, width: 2),
-                color: Colors.black.withOpacity(0.3),
+                color: Colors.black.withAlpha(76),
               ),
               child: CustomPaint(
                 painter: LandmarkPainter(_landmarks),
@@ -198,34 +203,14 @@ class _PoseLandmarkerViewState extends State<PoseLandmarkerView> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Container(
-                  padding: const EdgeInsets.all(8),
-                  color: Colors.black54,
-                  child: Text(
-                    'Landmarks: ${_landmarks.length}',
-                    style: const TextStyle(color: Colors.white),
-                  ),
-                ),
-                Container(
-                  padding: const EdgeInsets.all(8),
-                  color: Colors.black54,
-                  child: Text(
-                    'Camera: $_cameraLens',
-                    style: const TextStyle(color: Colors.white),
-                  ),
-                ),
-                Container(
-                  padding: const EdgeInsets.all(8),
-                  color: Colors.black54,
-                  child: Text(
-                    'FPS: $_fps',
-                    style: const TextStyle(color: Colors.white),
-                  ),
-                ),
+                _StatChip('Landmarks: ${_landmarks.length}'),
+                const SizedBox(height: 4),
+                _StatChip('Camera: $_cameraLens'),
+                const SizedBox(height: 4),
+                _StatChip('FPS: $_fps'),
               ],
             ),
           ),
-          // Confidence controls
           Positioned(
             bottom: 16,
             left: 16,
@@ -241,12 +226,12 @@ class _PoseLandmarkerViewState extends State<PoseLandmarkerView> {
                         child: TextField(
                           controller: _detectionController,
                           decoration: const InputDecoration(
-                            labelText: "Detection Confidence",
+                            labelText: 'Detection Confidence',
                             fillColor: Colors.white,
                             filled: true,
                           ),
-                          keyboardType:
-                              TextInputType.numberWithOptions(decimal: true),
+                          keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true),
                         ),
                       ),
                       const SizedBox(width: 8),
@@ -254,12 +239,12 @@ class _PoseLandmarkerViewState extends State<PoseLandmarkerView> {
                         child: TextField(
                           controller: _trackingController,
                           decoration: const InputDecoration(
-                            labelText: "Tracking Confidence",
+                            labelText: 'Tracking Confidence',
                             fillColor: Colors.white,
                             filled: true,
                           ),
-                          keyboardType:
-                              TextInputType.numberWithOptions(decimal: true),
+                          keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true),
                         ),
                       ),
                       const SizedBox(width: 8),
@@ -267,12 +252,12 @@ class _PoseLandmarkerViewState extends State<PoseLandmarkerView> {
                         child: TextField(
                           controller: _presenceController,
                           decoration: const InputDecoration(
-                            labelText: "Presence Confidence",
+                            labelText: 'Presence Confidence',
                             fillColor: Colors.white,
                             filled: true,
                           ),
-                          keyboardType:
-                              TextInputType.numberWithOptions(decimal: true),
+                          keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true),
                         ),
                       ),
                     ],
@@ -280,7 +265,7 @@ class _PoseLandmarkerViewState extends State<PoseLandmarkerView> {
                   const SizedBox(height: 8),
                   ElevatedButton(
                     onPressed: _applyConfidenceSettings,
-                    child: const Text("Apply"),
+                    child: const Text('Apply'),
                   ),
                 ],
               ),
@@ -288,6 +273,24 @@ class _PoseLandmarkerViewState extends State<PoseLandmarkerView> {
           ),
         ],
       ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────
+//  Helpers
+// ─────────────────────────────────────────────
+
+class _StatChip extends StatelessWidget {
+  final String text;
+  const _StatChip(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(8),
+      color: Colors.black54,
+      child: Text(text, style: const TextStyle(color: Colors.white)),
     );
   }
 }
@@ -305,40 +308,23 @@ class NativeCameraPreview extends StatelessWidget {
   }
 }
 
+// ─────────────────────────────────────────────
+//  Landmark painter
+// ─────────────────────────────────────────────
+
 class LandmarkPainter extends CustomPainter {
   final List<PoseLandmarkPoint> landmarks;
-  LandmarkPainter(this.landmarks);
+  const LandmarkPainter(this.landmarks);
 
   static const List<List<int>> connections = [
-    [0, 1],
-    [1, 2],
-    [2, 3],
-    [3, 7],
-    [0, 4],
-    [4, 5],
-    [5, 6],
-    [6, 8],
+    [0, 1], [1, 2], [2, 3], [3, 7],
+    [0, 4], [4, 5], [5, 6], [6, 8],
     [9, 10],
-    [11, 12],
-    [11, 13],
-    [13, 15],
-    [12, 14],
-    [14, 16],
-    [11, 23],
-    [12, 24],
-    [23, 24],
-    [23, 25],
-    [25, 27],
-    [24, 26],
-    [26, 28],
-    [27, 31],
-    [28, 32],
-    [15, 17],
-    [16, 18],
-    [17, 19],
-    [18, 20],
-    [19, 21],
-    [20, 22],
+    [11, 12], [11, 13], [13, 15], [12, 14], [14, 16],
+    [11, 23], [12, 24], [23, 24],
+    [23, 25], [25, 27], [24, 26], [26, 28],
+    [27, 31], [28, 32],
+    [15, 17], [16, 18], [17, 19], [18, 20], [19, 21], [20, 22],
   ];
 
   @override
@@ -351,7 +337,7 @@ class LandmarkPainter extends CustomPainter {
       ..color = Colors.blue
       ..strokeWidth = 2;
 
-    for (var c in connections) {
+    for (final c in connections) {
       if (c[0] < landmarks.length && c[1] < landmarks.length) {
         final a = landmarks[c[0]];
         final b = landmarks[c[1]];
@@ -363,7 +349,7 @@ class LandmarkPainter extends CustomPainter {
       }
     }
 
-    for (var lm in landmarks) {
+    for (final lm in landmarks) {
       canvas.drawCircle(
         Offset(lm.x * size.width, lm.y * size.height),
         4,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.2"
+    version: "0.1.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_mp_pose_landmarker
 description: "A Flutter plugin for real-time pose detection using MediaPipe and native CameraX."
-version: 0.1.3
+version: 0.1.5
 homepage: https://github.com/mohammed893/flutter_pose_mediapipe/tree/main
 repository: https://github.com/mohammed893/flutter_pose_mediapipe
 issue_tracker: https://github.com/mohammed893/flutter_pose_mediapipe/issues
@@ -20,6 +20,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^4.0.0
   mockito: ^5.4.4
+
 
 flutter:
 


### PR DESCRIPTION

The plugin was binding to the camera hardware immediately on activity attach, holding it even when pose detection was not in use. This caused the camera package and other consumers to get a blank preview or fail silently on any screen that didn't use the plugin.

- Defer startCamera() from onAttachedToActivity to onListen
- Call releaseCamera() (unbindAll) in onCancel so hardware is freed as soon as the Dart subscription is cancelled or the widget disposes
- Extend IPoseManager with releaseCamera() to formalize the contract
- Add !mounted guard in stream listener to prevent post-dispose setState
- No API changes — existing integrations require no migration